### PR TITLE
Throw errors instead of objects

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -133,9 +133,9 @@ Client.prototype.executeResource = function(opts, callback) {
   }
 
   if (!opts.catalog && !this.catalog)
-    throw {message: "catalog not specified"};
+    throw new Error("catalog not specified");
   if (!opts.schema && !this.schema)
-    throw {message: "schema not specified"};
+    throw new Error("schema not specified");
 
   var header = {};
   header[Headers.CATALOG] = opts.catalog || this.catalog;
@@ -158,11 +158,11 @@ Client.prototype.statementResource = function(opts) {
   var columns = null;
 
   if (!opts.catalog && !this.catalog)
-    throw {message: "catalog not specified"};
+    throw new Error("catalog not specified");
   if (!opts.schema && !this.schema)
-    throw {message: "schema not specified"};
+    throw new Error("schema not specified");
   if (!opts.success && !opts.callback)
-    throw {message: "callback function 'success' (or 'callback') not specified"};
+    throw new Error("callback function 'success' (or 'callback') not specified");
 
   var header = {};
   header[Headers.CATALOG] = opts.catalog || this.catalog;


### PR DESCRIPTION
Throw an Error instead of an object to preserve an error's stack trace and increase compability with promise libraries.
